### PR TITLE
Fixed regex syntax error in .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,5 +2,7 @@
 ^\.Rproj\.user$
 ^LICENSE\.md$
 ^README.Rmd$
-docs/*
-*.o
+^docs/.*$
+^.*\.o$
+^.*\.a$
+^\.github$


### PR DESCRIPTION
Syntax errors in the regex for .o files in .Rbuildignore led to an error while installing the package with remotes::install_github(). Fixed.