### PR TITLE
fix: project starting_point into reduced space

### DIFF
--- a/R/rlim.R
+++ b/R/rlim.R
@@ -230,6 +230,9 @@ rlim<- function(lim, Hpol = NULL,
     random_walk<-c(random_walk,list("nburns"=burn))
   }
   if (!is.null(starting_point)){
+    if (is.null(Hpol)) {
+      starting_point <- as.numeric(MASS::ginv(Z) %*% (as.numeric(starting_point) - x0))
+    }
     random_walk<-c(random_walk,list("starting_point"=starting_point))
   }
   if (!is.null(seed)){


### PR DESCRIPTION
Fixes the "Starting Point has to lie in the same dimension as the polytope P" error raised by `rlim()` whenever a `starting_point` is supplied together with a LIM containing equality constraints (`lim$A`/`lim$B`).  
`rlim()` reduces the polytope via `lim.redpol()` before calling `sample_points()`, but was forwarding `starting_point` unchanged, in the original (unknowns) space, instead of projecting it into the reduced space via `x0`/`Z`. This patch adds that projection using `MASS::ginv()`.